### PR TITLE
Added type:string to pieces table

### DIFF
--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -4,22 +4,19 @@ class Pawn < Piece
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
 
-# ----- Opening move ----- 
-    if y_coord == 2 && white?
+# ----- Opening move -----
+    if y_coord == 2 && black?
       x_distance == 0 && (new_y_coord == 3 || new_y_coord == 4)
-    elsif y_coord == 7 && black?
-      x_distance == 0 && (new_y_coord == 6 || new_y_coord == 5)  
-  
+    elsif y_coord == 7 && white?
+      x_distance == 0 && (new_y_coord == 6 || new_y_coord == 5)
+
 # ----- Otherwise -------
-    else 
-      if white?
+    else
+      if black?
         (x_distance == 0) && (new_y_coord == (y_coord + 1))
-      elsif black? 
+      elsif white? 
         (x_distance == 0) && (new_y_coord == (y_coord - 1))
-      end  
+      end
     end
   end
 end
-
-
-

--- a/db/migrate/20171111042923_remove_type_from_pieces.rb
+++ b/db/migrate/20171111042923_remove_type_from_pieces.rb
@@ -1,0 +1,5 @@
+class RemoveTypeFromPieces < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :pieces, :type, :string
+  end
+end

--- a/db/migrate/20171111043047_add_type_to_piece.rb
+++ b/db/migrate/20171111043047_add_type_to_piece.rb
@@ -1,0 +1,5 @@
+class AddTypeToPiece < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pieces, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171110201234) do
+ActiveRecord::Schema.define(version: 20171111043047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20171110201234) do
     t.integer "y_coord"
     t.integer "game_id"
     t.integer "user_id"
+    t.string "type"
   end
 
   create_table "user_games", force: :cascade do |t|

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -1,58 +1,58 @@
 require 'rails_helper'
 
 RSpec.describe Pawn, type: :model do
-  
+
   describe "#valid move?" do
 
-# ------ Opening Move ------------    
+# ------ Opening Move ------------
 
     it "should return true to move one square forward on first move" do
       game = Game.create
-      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 2, game_id: game.id, white: true 
+      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 2, game_id: game.id, white: false
       expect(pawn.valid_move?(2, 3)).to eq(true)
     end
 
     it "should return true to move two squares forward on first move" do
       game = Game.create
-      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 7, game_id: game.id, white: false
+      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 7, game_id: game.id, white: true
       expect(pawn.valid_move?(2, 5)).to eq(true)
     end
 
     it "should return false to move three squares forward on first move" do
       game = Game.create
-      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 2, game_id: game.id, white: true
+      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 2, game_id: game.id, white: false
       expect(pawn.valid_move?(2, 5)).to eq(false)
     end
 
     it "should return false to move one square sideways on first move" do
       game = Game.create
-      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 2, game_id: game.id, white: true
+      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 2, game_id: game.id, white: false
       expect(pawn.valid_move?(3, 2)).to eq(false)
     end
 
-# ------ Subsequent Moves ------------    
-
-    it "should return true for white pawn to move one square forward" do
-      game = Game.create
-      pawn = FactoryGirl.create :pawn, x_coord: 5, y_coord: 5, game_id: game.id, white: true
-      expect(pawn.valid_move?(5, 6)).to eq(true)
-    end
+# ------ Subsequent Moves ------------
 
     it "should return true for black pawn to move one square forward" do
       game = Game.create
       pawn = FactoryGirl.create :pawn, x_coord: 5, y_coord: 5, game_id: game.id, white: false
-      expect(pawn.valid_move?(5, 4)).to eq(true)
+      expect(pawn.valid_move?(5, 6)).to eq(true)
     end
 
-    it "should return false for white pawn to move backward" do
+    it "should return true for white pawn to move one square forward" do
       game = Game.create
       pawn = FactoryGirl.create :pawn, x_coord: 5, y_coord: 5, game_id: game.id, white: true
-      expect(pawn.valid_move?(5, 4)).to eq(false)
+      expect(pawn.valid_move?(5, 4)).to eq(true)
     end
 
     it "should return false for black pawn to move backward" do
       game = Game.create
       pawn = FactoryGirl.create :pawn, x_coord: 5, y_coord: 5, game_id: game.id, white: false
+      expect(pawn.valid_move?(5, 4)).to eq(false)
+    end
+
+    it "should return false for white pawn to move backward" do
+      game = Game.create
+      pawn = FactoryGirl.create :pawn, x_coord: 5, y_coord: 5, game_id: game.id, white: true
       expect(pawn.valid_move?(5, 6)).to eq(false)
     end
 
@@ -67,5 +67,5 @@ RSpec.describe Pawn, type: :model do
       pawn = FactoryGirl.create :pawn, x_coord: 5, y_coord: 2, game_id: game.id, white: true
       expect(pawn.valid_move?(6, 2)).to eq(false)
     end
-  end 
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,12 +21,12 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-if ActiveRecord::Migrator.needs_migration?
-  ActiveRecord::Migrator.migrate(File.join(Rails.root, 'db/migrate'))
-end
+#if ActiveRecord::Migrator.needs_migration?
+#  ActiveRecord::Migrator.migrate(File.join(Rails.root, 'db/migrate'))
+#end
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
+#ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
Hi all,

In order for single inheritance to work, we had added type:string column to the pieces table.
For some reason, it was deleted, and this PR adds it back.

****Once merged, please run Rake db:migrate. ****

