### PR TITLE
Verify a piece belongs to a player before moving

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,5 +1,5 @@
 class PiecesController < ApplicationController
-  before_action :find_piece, :verify_player_turn, :verify_valid_move
+  before_action :find_piece, :verify_player_turn, :verify_valid_move, :verify_player_piece
   def update
     @game = @piece.game
     @piece.update_attributes(piece_params)
@@ -39,5 +39,10 @@ class PiecesController < ApplicationController
 
   def piece_params
     params.require(:piece).permit(:x_coord, :y_coord)
+  end
+
+  def verify_player_piece
+    return if @piece.user.nil? || current_user.id = @piece.game.turn_user_id
+    render json: {}, status: 422
   end
 end

--- a/db/migrate/20171111042923_remove_type_from_pieces.rb
+++ b/db/migrate/20171111042923_remove_type_from_pieces.rb
@@ -1,5 +1,0 @@
-class RemoveTypeFromPieces < ActiveRecord::Migration[5.1]
-  def change
-    remove_column :pieces, :type, :string
-  end
-end

--- a/db/migrate/20171111195755_add_type_to_pieces.rb
+++ b/db/migrate/20171111195755_add_type_to_pieces.rb
@@ -1,4 +1,4 @@
-class AddTypeToPiece < ActiveRecord::Migration[5.1]
+class AddTypeToPieces < ActiveRecord::Migration[5.1]
   def change
     add_column :pieces, :type, :string
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171111043047) do
+ActiveRecord::Schema.define(version: 20171111195755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 20171111043047) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.index ["name"], name: "index_games_on_name"
   end
 
   create_table "pieces", force: :cascade do |t|


### PR DESCRIPTION
Verify a piece belongs to a player before allowing it to move. Also includes fixes from previous bug with pieces table. ** must db:migrate