### PR TITLE
Piece belongs to player

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -2,6 +2,7 @@ class PiecesController < ApplicationController
   before_action :find_piece, :verify_player_turn, :verify_valid_move, :verify_player_piece
   def update
     @game = @piece.game
+    piece_move #??????????????????????????????????????????????
     @piece.update_attributes(piece_params)
     switch_turns
     render json: {}, status: 200
@@ -49,3 +50,7 @@ class PiecesController < ApplicationController
     render json: {}, status: 422
   end
 end
+
+
+
+

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -3,7 +3,8 @@ class Piece < ApplicationRecord
   belongs_to :user, required: false
 
 
-  def piece_move
+   def piece_move 
+    return false if piece_belongs_to_opponent
     capture_piece = find_capture_piece(x_end, y_end)
     if capture_piece.nil?
       move_to_empty_square(x_end, y_end)
@@ -11,6 +12,13 @@ class Piece < ApplicationRecord
     else
       capture(capture_piece)
       move_to_capture_piece_and_capture
+    end
+  end
+
+  def piece_belongs_to_opponent (piece)
+    return if (@game.white_player_user_id == current_user.id && @piece.black) || (@game.black_player_user_id == current_user.id && @piece.white)
+    else
+      render json: {}, status: 422
     end
   end
 
@@ -102,7 +110,7 @@ class Piece < ApplicationRecord
   end
 
   def remove_piece(dead_piece)
-    dead_piece.update_attributes(is_on_board?: false, row_coordinate: -1, column_coordinate: -1)
+    dead_piece.update_attributes(x_coord: nil, y_coord: nil) ##Should we have a piece status to add to db? Like captured/in play? This would be helpful for stats also
   end
 
   def move_to_empty_square(x_end, y_end)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -98,7 +98,7 @@ class Piece < ApplicationRecord
 
   def capture(capture_piece)
     move_to_empty_square(capture_piece.x_coord, capture_piece.y_coord)
-    remove_piece(destination_piece)
+    remove_piece(capture_piece)
   end
 
   def remove_piece(dead_piece)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,6 +2,18 @@ class Piece < ApplicationRecord
   belongs_to :game
   belongs_to :user, required: false
 
+
+  def piece_move
+    capture_piece = find_capture_piece(x_end, y_end)
+    if capture_piece.nil?
+      move_to_empty_square(x_end, y_end)
+    return false if capture_piece !capturable
+    else
+      capture(capture_piece)
+      move_to_capture_piece_and_capture
+    end
+  end
+
   def contains_own_piece?(x_end, y_end)
     piece = game.pieces.where("x_coord = ? AND y_coord = ?", x_end, y_end).first
     piece.present? && piece.white? == white?
@@ -69,6 +81,32 @@ class Piece < ApplicationRecord
 
   def diagonal?(x_distance, y_distance)
     x_distance == y_distance
+  end
+
+  def capturable(capture_piece)
+    (capture_piece.present? && capture_piece.color != color) 
+  end
+
+  def find_capture_piece(x_end, y_end)
+    game.pieces.find_by(x_coord: x_end, y_coord: y_end)
+  end
+
+  def move_to_capture_piece_and_capture(dead_piece, x_end, y_end)
+    update_attributes(x_coord: x_end, y_coord: y_end)
+    remove_piece(dead_piece)
+  end
+
+  def capture(capture_piece)
+    move_to_empty_square(capture_piece.x_coord, capture_piece.y_coord)
+    remove_piece(destination_piece)
+  end
+
+  def remove_piece(dead_piece)
+    dead_piece.update_attributes(is_on_board?: false, row_coordinate: -1, column_coordinate: -1)
+  end
+
+  def move_to_empty_square(x_end, y_end)
+    update_attributes(x_coord: x_end, y_coord: y_end)
   end
 
 end


### PR DESCRIPTION
This method is built into the move-piece method in the previous PR. I tried to do this in the p/c but since there was technically no turn id or piece yet (as everything is a before action) I could not successfully implement it there. This checks that a piece does not belong to an opponent before the piece moves.