### PR TITLE
Removed 'end' in db:seeds in order to run rake db:seed in heroku

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,4 +8,3 @@
 
 #User.find_or_create_by(:email => "test2@gmail.com", :password => "password", :password_confirmation => "password")
 #Game.create
-#end


### PR DESCRIPTION
Hi All!

I was trying to see how our app is in heroku, and ran into some errors with rspec testing due to it not detecting the Inheritance, so I wanted to do:
heroku run rake db:seed in order to refresh the migrations.

However, the rake was aborted due to an unexpected 'end' in seeds.rb, so I am trying to make the rake work by deleting 'end' in this branch.

If you can approve this PR and merge, that would be great!