### PR TITLE
Feat Check Logic and Checkmate Logic

### DIFF
--- a/0
+++ b/0
@@ -1,0 +1,2 @@
+      invoke  active_record
+      create    db/migrate/20171118232146_add_column.rb

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -5,6 +5,11 @@ class PiecesController < ApplicationController
     @game = @piece.game
     is_captured
     @piece.update_attributes(piece_params.merge(move_number: @piece.move_number + 1))
+    #Below king_opp mean the opponent's player's king. After the player's turn,
+    #we'd like to know if the opponent king is in check, and if in check, does
+    #the opponent's king have any way to get out of check (see check_mate in king.rb)
+    #if the opponent's king is stuck, the game is over, right now noted by the 401 error
+    #will need to do a proper game end
     king_opp = @game.pieces.where(:type =>"King").where.not(:user_id => @game.turn_user_id)[0]
     if king_opp.check?(king_opp.x_coord, king_opp.y_coord)
       if king_opp.find_threat_and_determine_checkmate(king_opp)
@@ -62,6 +67,9 @@ class PiecesController < ApplicationController
   end
 
   def player_moves_own_king_to_check_or_keeps_king_in_check?
+    #function checks if player is not moving king into a check position
+    #and also checking that if king is in check, player must move king out of check,
+    #this function restricts any other random move if king is in check.
     king = @game.pieces.where(:type =>"King").where(:user_id => @game.turn_user_id)[0]
     if @piece.type == "King"
       if @piece.check?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == true

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,20 +1,19 @@
 class PiecesController < ApplicationController
   before_action :find_piece, :verify_player_turn, :verify_valid_move
+
   def update
     @game = @piece.game
-    #@piece.update_attributes(piece_params.merge(move_number: @piece.move_number + 1)
-
     is_captured
-    @piece.update_attributes(piece_params)
-    king = @game.pieces.find_by(type:"King", user_id: @game.turn_user_id)
-    if king.check?(king.x_coord, king.y_coord)
-      if king.find_threat_and_determine_checkmate(king)
-        king.update_winner
+    @piece.update_attributes(piece_params.merge(move_number: @piece.move_number + 1))
+    king_opp = @game.pieces.where(:type =>"King").where.not(:user_id => @game.turn_user_id)[0]
+    if king_opp.check?(king_opp.x_coord, king_opp.y_coord)
+      if king_opp.find_threat_and_determine_checkmate(king_opp)
+        king_opp.update_winner
+        render json: {}, status: 401
       end
-    else
-      switch_turns
-      render json: {}, status: 200
     end
+    switch_turns
+    render json: {}, status: 200
   end
 
   private
@@ -36,7 +35,7 @@ class PiecesController < ApplicationController
     return if @piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) &&
     (@piece.is_obstructed(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == false) &&
     (@piece.contains_own_piece?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == false) &&
-    (player_moving_own_king_to_check? == false)
+    (player_moves_own_king_to_check_or_keeps_king_in_check? == false)
     render json: {}, status: 422
   end
 
@@ -62,15 +61,19 @@ class PiecesController < ApplicationController
     end
   end
 
-  def player_moving_own_king_to_check?
+  def player_moves_own_king_to_check_or_keeps_king_in_check?
+    king = @game.pieces.where(:type =>"King").where(:user_id => @game.turn_user_id)[0]
     if @piece.type == "King"
       if @piece.check?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == true
         return true
       else
         return false
       end
+    elsif @piece.type != "King" && king.check?(king.x_coord,king.y_coord)
+      return true
+    else
+      return false
     end
-    return false
   end
 
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -4,9 +4,79 @@ class King < Piece
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
 
-    x_distance == 1 || y_distance == 1
+    (x_distance == 1 && y_distance == 0) ||
+    (y_distance == 1 && x_distance == 0) ||
+    (y_distance == 1 && y_distance == x_distance)
   end
 
+  def check?(x_coord, y_coord)
+    game.pieces.each do | f |
+      if f.user_id != game.turn_user_id && f.x_coord != nil
+        if f.valid_move?(x_coord, y_coord) == true && f.is_obstructed(x_coord, y_coord) == false
+          return true
+        end
+      end
+    end
+    return false
+  end
+
+  def find_threat_and_determine_checkmate (king)
+    threat = find_threat
+    if check_mate?(king,threat)
+      return true
+    end
+    return false
+  end
+
+  def find_threat
+    game.pieces.each do | f |
+      if f.user_id != game.turn_user_id && f.x_coord != nil
+        if f.valid_move?(x_coord, y_coord) && f.is_obstructed(x_coord,y_coord) == false
+          return f
+        end
+      end
+    end
+  end
+
+  def check_mate? (king, threat)
+    obstruction_array = threat.build_obstruction_array(king.x_coord, king.y_coord)
+    # check if king can capture the threat
+    if king.valid_move?(threat.x_coord, threat.y_coord) == true ||
+    # check if any other piece can move to block the king
+      threat.type != "Knight" && can_block_king?(king,threat,obstruction_array) == true ||
+    # check if king has many moves left
+      any_moves_left?(king,threat,obstruction_array) == true
+      return false
+    else
+      return true
+    end
+  end
+
+  private
+
+  def any_moves_left?(king,threat,obstruction_array)
+    possible_coords = []
+    (1..8).each do |num1|
+      (1..8).each do |num2|
+        if king.valid_move?(num1,num2) == true && king.contains_own_piece?(num1,num2) == false
+          possible_coords << [num1, num2]
+        end
+      end
+    end
+    return true if (possible_coords - obstruction_array).count >= 1
+  end
+
+  def can_block_king?(king,threat,obstruction_array)
+    game.pieces.each do |f|
+      if f.user_id == game.turn_user_id && f.x_coord != nil
+        obstruction_array.each do |coord|
+          return true if f.valid_move?(coord[0],coord[1]) == true &&
+          f.contains_own_piece?(coord[0],coord[1]) == false &&
+          f.is_obstructed(coord[0],coord[1]) == false
+          break
+        end
+      end
+    end
+    return false
+  end
 end
-
-

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -11,7 +11,7 @@ class King < Piece
 
   def check?(x_coord, y_coord)
     game.pieces.each do | f |
-      if f.user_id != game.turn_user_id && f.x_coord != nil
+      if f.user_id != self.user_id && f.x_coord != nil
         if f.valid_move?(x_coord, y_coord) == true && f.is_obstructed(x_coord, y_coord) == false
           return true
         end
@@ -20,7 +20,7 @@ class King < Piece
     return false
   end
 
-  def find_threat_and_determine_checkmate (king)
+  def find_threat_and_determine_checkmate(king)
     threat = find_threat
     if check_mate?(king,threat)
       return true
@@ -28,17 +28,7 @@ class King < Piece
     return false
   end
 
-  def find_threat
-    game.pieces.each do | f |
-      if f.user_id != game.turn_user_id && f.x_coord != nil
-        if f.valid_move?(x_coord, y_coord) && f.is_obstructed(x_coord,y_coord) == false
-          return f
-        end
-      end
-    end
-  end
-
-  def check_mate? (king, threat)
+  def check_mate?(king, threat)
     obstruction_array = threat.build_obstruction_array(king.x_coord, king.y_coord)
     # check if king can capture the threat
     if king.valid_move?(threat.x_coord, threat.y_coord) == true ||
@@ -53,6 +43,21 @@ class King < Piece
   end
 
   private
+
+  def find_threat
+    threat_found = false
+    while threat_found != true
+      game.pieces.each do | f |
+        if f.user_id != game.turn_user_id && f.x_coord != nil
+          if f.valid_move?(x_coord, y_coord) && f.is_obstructed(x_coord,y_coord) == false
+            return f
+            threat_found = true
+          end
+        end
+      end
+      threat_found
+    end
+  end
 
   def any_moves_left?(king,threat,obstruction_array)
     possible_coords = []

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -103,28 +103,27 @@ class Piece < ApplicationRecord
   #  update_attributes(x_coord: x_end, y_coord: y_end)
   #end
 
+  #build_obstruction_array is identical to is_obstruct, except that we want the array, and not the boolean
   def build_obstruction_array(x_end, y_end)
-  y_change = y_coord - y_end
-  x_change = x_coord - x_end
+    y_change = y_coord - y_end
+    x_change = x_coord - x_end
 
-  # Build array squares which piece must move through
-  obstruction_array = []
-  if x_change.abs == 0 # If it's moving vertically
-    (1..(y_change.abs-1)).each do |i|
-        obstruction_array << [x_coord, y_coord - (y_change/y_change.abs) * i]
+    # Build array squares which piece must move through
+    obstruction_array = []
+    if x_change.abs == 0 # If it's moving vertically
+      (1..(y_change.abs-1)).each do |i|
+          obstruction_array << [x_coord, y_coord - (y_change/y_change.abs) * i]
+      end
+    elsif y_change.abs == 0 # If horizontally
+      (1..(x_change.abs-1)).each do |i| # 7 times do (0..6).each do
+          obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord]
+      end
+    elsif y_change.abs == x_change.abs #if diagonally
+      (1..(y_change.abs-1)).each do |i|
+          obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord - (y_change/y_change.abs) * i]
+      end
     end
-  elsif y_change.abs == 0 # If horizontally
-    (1..(x_change.abs-1)).each do |i| # 7 times do (0..6).each do
-        obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord]
-    end
-  elsif y_change.abs == x_change.abs #if diagonally
-    (1..(y_change.abs-1)).each do |i|
-        obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord - (y_change/y_change.abs) * i]
-    end
-  end
-
-  # Check if end square contains own piece and if any of in between squares have a piece of any colour in
-  obstruction_array
+    obstruction_array
   end
 
   def update_winner

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -14,7 +14,8 @@ class Piece < ApplicationRecord
     piece.present? && piece.white? == white?
   end
 
-  def is_obstructed(x_end, y_end)
+  #build_obstruction_array is identical to is_obstruct, except that we want the array, and not the boolean
+  def build_obstruction_array(x_end, y_end)
     y_change = y_coord - y_end
     x_change = x_coord - x_end
 
@@ -33,6 +34,11 @@ class Piece < ApplicationRecord
           obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord - (y_change/y_change.abs) * i]
       end
     end
+    obstruction_array
+  end
+
+  def is_obstructed(x_end, y_end)
+    obstruction_array = build_obstruction_array(x_end, y_end)
     # Check if end square contains own piece and if any of in between squares have a piece of any colour in
     obstruction_array.any?{|square| game.contains_piece?(square[0], square[1]) == true}
   end
@@ -102,29 +108,6 @@ class Piece < ApplicationRecord
   #def move_to_empty_square(x_end, y_end)
   #  update_attributes(x_coord: x_end, y_coord: y_end)
   #end
-
-  #build_obstruction_array is identical to is_obstruct, except that we want the array, and not the boolean
-  def build_obstruction_array(x_end, y_end)
-    y_change = y_coord - y_end
-    x_change = x_coord - x_end
-
-    # Build array squares which piece must move through
-    obstruction_array = []
-    if x_change.abs == 0 # If it's moving vertically
-      (1..(y_change.abs-1)).each do |i|
-          obstruction_array << [x_coord, y_coord - (y_change/y_change.abs) * i]
-      end
-    elsif y_change.abs == 0 # If horizontally
-      (1..(x_change.abs-1)).each do |i| # 7 times do (0..6).each do
-          obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord]
-      end
-    elsif y_change.abs == x_change.abs #if diagonally
-      (1..(y_change.abs-1)).each do |i|
-          obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord - (y_change/y_change.abs) * i]
-      end
-    end
-    obstruction_array
-  end
 
   def update_winner
     if white?

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -134,4 +134,5 @@ class Piece < ApplicationRecord
       game.update_attributes(winner_user_id: game.white_player_user_id)
     end
   end
+
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -33,7 +33,6 @@ class Piece < ApplicationRecord
           obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord - (y_change/y_change.abs) * i]
       end
     end
-
     # Check if end square contains own piece and if any of in between squares have a piece of any colour in
     obstruction_array.any?{|square| game.contains_piece?(square[0], square[1]) == true}
   end
@@ -103,4 +102,36 @@ class Piece < ApplicationRecord
   #def move_to_empty_square(x_end, y_end)
   #  update_attributes(x_coord: x_end, y_coord: y_end)
   #end
+
+  def build_obstruction_array(x_end, y_end)
+  y_change = y_coord - y_end
+  x_change = x_coord - x_end
+
+  # Build array squares which piece must move through
+  obstruction_array = []
+  if x_change.abs == 0 # If it's moving vertically
+    (1..(y_change.abs-1)).each do |i|
+        obstruction_array << [x_coord, y_coord - (y_change/y_change.abs) * i]
+    end
+  elsif y_change.abs == 0 # If horizontally
+    (1..(x_change.abs-1)).each do |i| # 7 times do (0..6).each do
+        obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord]
+    end
+  elsif y_change.abs == x_change.abs #if diagonally
+    (1..(y_change.abs-1)).each do |i|
+        obstruction_array << [x_coord - (x_change/x_change.abs) * i, y_coord - (y_change/y_change.abs) * i]
+    end
+  end
+
+  # Check if end square contains own piece and if any of in between squares have a piece of any colour in
+  obstruction_array
+  end
+
+  def update_winner
+    if white?
+      game.update_attributes(winner_user_id: game.black_player_user_id)
+    else
+      game.update_attributes(winner_user_id: game.white_player_user_id)
+    end
+  end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,8 +20,10 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: postgres
-  password: password
+  #username: postgres
+  #password: password
+  username: monicasira
+  password:
   host: localhost
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,10 +20,8 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  #username: postgres
-  #password: password
-  username: monicasira
-  password:
+  username: postgres
+  password: password
   host: localhost
 
 development:

--- a/db/migrate/20171118232238_add_king_check_to_pieces.rb
+++ b/db/migrate/20171118232238_add_king_check_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddKingCheckToPieces < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pieces, :king_check, :integer, :default => 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171113214239) do
+ActiveRecord::Schema.define(version: 20171118232238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,9 @@ ActiveRecord::Schema.define(version: 20171113214239) do
     t.integer "game_id"
     t.integer "user_id"
     t.string "type"
+    t.boolean "captured", default: false, null: false
     t.integer "move_number", default: 0
+    t.integer "king_check", default: 0
   end
 
   create_table "user_games", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115212045) do
+ActiveRecord::Schema.define(version: 20171113214239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,6 @@ ActiveRecord::Schema.define(version: 20171115212045) do
     t.integer "game_id"
     t.integer "user_id"
     t.string "type"
-    t.boolean "captured", default: false, null: false
     t.integer "move_number", default: 0
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171113214239) do
+ActiveRecord::Schema.define(version: 20171115212045) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20171113214239) do
     t.integer "game_id"
     t.integer "user_id"
     t.string "type"
+    t.boolean "captured", default: false, null: false
     t.integer "move_number", default: 0
   end
 

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -72,6 +72,46 @@ RSpec.describe PiecesController, type: :controller do
     expect(response).to have_http_status(422)
   end
 
+  it "should return status 401 if opponent king is in check and cannot move out of check" do
+    current_user = FactoryGirl.create(:user, id: 1)
+    sign_in current_user
+    game = Game.create turn_user_id: 1, white_player_user_id: 1, black_player_user_id: 2
+    black_king = game.pieces.find_by(name:"King_black")
+    black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 2)
+    white_pawn = game.pieces.where(name: "Pawn_white")
+    white_pawn.delete_all
+    black_pawn = game.pieces.where(name: "Pawn_black")
+    black_pawn.update_all(user_id: 2)
+    rook = game.pieces.find_by(name: "Rook_white")
+    rook.update_attributes(user_id: 1, x_coord:1, y_coord:8)
+    black_piece1 = FactoryGirl.create(:pawn,user_id: 2,x_coord:1, y_coord: 3, game_id: game.id, white:false)
+    black_piece2 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 3, game_id: game.id, white:false)
+    black_piece3 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 4, game_id: game.id, white:false)
+    black_piece4 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 5, game_id: game.id, white:false)
+    post :update, params: {id: rook.id, piece: {x_coord:1, y_coord:7 }}
+    expect(response).to have_http_status(401)
   end
+
+  it "should return status 401 if opponent king is in check and cannot move out of check" do
+    current_user = FactoryGirl.create(:user, id: 1)
+    sign_in current_user
+    game = Game.create turn_user_id: 1, white_player_user_id: 1, black_player_user_id: 2
+    black_king = game.pieces.find_by(name:"King_black")
+    black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 2)
+    white_pawn = game.pieces.where(name: "Pawn_white")
+    white_pawn.delete_all
+    black_pawn = game.pieces.where(name: "Pawn_black")
+    black_pawn.update_all(user_id: 2)
+    rook = game.pieces.find_by(name: "Rook_white")
+    rook.update_attributes(user_id: 1, x_coord:1, y_coord:8)
+    black_piece1 = FactoryGirl.create(:pawn,user_id: 2,x_coord:1, y_coord: 3, game_id: game.id, white:false)
+    black_piece2 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 3, game_id: game.id, white:false)
+    black_piece3 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 4, game_id: game.id, white:false)
+    post :update, params: {id: rook.id, piece: {x_coord:1, y_coord:7 }}
+    black_king.reload
+    expect(black_king.king_check).to eq 1
+    expect(response).to have_http_status(200)
+  end
+end
 
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe King, type: :model do
      game = Game.create turn_user_id: user.id
      king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 4, game_id: game.id, user_id: user.id
-     expect(king.check?(king.x_coord, king.y_coord)).to eq(true)
+     threat = king.check?(king.x_coord, king.y_coord)
+     expect(threat.present?).to eq(true)
     end
 
    it "should return false to put king in check" do
@@ -55,7 +56,8 @@ RSpec.describe King, type: :model do
      game = Game.create turn_user_id: user.id
      king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
      rook = FactoryGirl.create :rook, x_coord: 7, y_coord: 4, game_id: game.id, user_id: user.id
-     expect(king.check?(king.x_coord, king.y_coord)).to eq(false)
+     threat = king.check?(king.x_coord, king.y_coord)
+     expect(threat).to eq(false)
     end
 
     it "should return true for rook to put king in check" do
@@ -63,7 +65,8 @@ RSpec.describe King, type: :model do
      game = Game.create turn_user_id: user.id
      king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
      rook = FactoryGirl.create :rook, x_coord: 3, y_coord: 7, game_id: game.id, user_id: user.id
-     expect(king.check?(king.x_coord, king.y_coord)).to eq(true)
+     threat = king.check?(king.x_coord, king.y_coord)
+     expect(threat.present?).to eq(true)
     end
  end
 
@@ -82,7 +85,7 @@ RSpec.describe King, type: :model do
      black_piece2 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 3, game_id: game.id, white:false)
      black_piece3 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 4, game_id: game.id, white:false)
      black_piece4 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 5, game_id: game.id, white:false)
-     expect(black_king.find_threat_and_determine_checkmate(black_king)).to eq true
+     expect(black_king.find_threat_and_determine_checkmate).to eq true
    end
  end
 
@@ -97,7 +100,7 @@ RSpec.describe King, type: :model do
      black_pawn.update_all(user_id: 1)
      rook = game.pieces.find_by(name: "Rook_white")
      rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
-     expect(black_king.check_mate?(black_king, rook)).to eq false
+     expect(black_king.check_mate?(rook)).to eq false
    end
 
    it "should return false if any other piece(knight example) can help block king" do
@@ -112,7 +115,7 @@ RSpec.describe King, type: :model do
      rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
      black_knight = game.pieces.find_by(name:"Knight_black")
      black_knight.update_attributes(x_coord:2, y_coord:5, user_id: 1)
-     expect(black_king.check_mate?(black_king, rook)).to eq false
+     expect(black_king.check_mate?(rook)).to eq false
    end
 
    it "should return true if the king has no valid moves, no piece can help block and king cannot capture threat" do
@@ -129,7 +132,7 @@ RSpec.describe King, type: :model do
      black_piece2 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 3, game_id: game.id, white:false)
      black_piece3 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 4, game_id: game.id, white:false)
      black_piece4 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 5, game_id: game.id, white:false)
-     expect(black_king.check_mate?(black_king, rook)).to eq true
+     expect(black_king.check_mate?(rook)).to eq true
    end
  end
 

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -41,12 +41,13 @@ RSpec.describe King, type: :model do
 
  end
  describe "#check?" do
+   #diagonal capture will pass once merged. It is failing for now because lacking diagonal logic
    it "should return true for pawn to put king in check" do
      user = FactoryGirl.create :user
      game = Game.create turn_user_id: user.id
      king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
      pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 4, game_id: game.id, user_id: user.id
-     expect(king.check?).to eq(true)
+     expect(king.check?(king.x_coord, king.y_coord)).to eq(true)
     end
 
    it "should return false to put king in check" do
@@ -54,7 +55,7 @@ RSpec.describe King, type: :model do
      game = Game.create turn_user_id: user.id
      king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
      rook = FactoryGirl.create :rook, x_coord: 7, y_coord: 4, game_id: game.id, user_id: user.id
-     expect(king.check?).to eq(false)
+     expect(king.check?(king.x_coord, king.y_coord)).to eq(false)
     end
 
     it "should return true for rook to put king in check" do
@@ -62,7 +63,7 @@ RSpec.describe King, type: :model do
      game = Game.create turn_user_id: user.id
      king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
      rook = FactoryGirl.create :rook, x_coord: 3, y_coord: 7, game_id: game.id, user_id: user.id
-     expect(king.check?).to eq(true)
+     expect(king.check?(king.x_coord, king.y_coord)).to eq(true)
     end
  end
 
@@ -81,23 +82,7 @@ RSpec.describe King, type: :model do
      black_piece2 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 3, game_id: game.id, white:false)
      black_piece3 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 4, game_id: game.id, white:false)
      black_piece4 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 5, game_id: game.id, white:false)
-     expect(black_king.find_threat).to eq rook
      expect(black_king.find_threat_and_determine_checkmate(black_king)).to eq true
-   end
- end
-
- describe "#find_threat" do
-   it "should return the piece that is checking the king" do
-     game = Game.create turn_user_id: 1
-     black_king = game.pieces.find_by(name:"King_black")
-     black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 1)
-     white_pawn = game.pieces.where(name: "Pawn_white")
-     white_pawn.delete_all
-     black_pawn = game.pieces.where(name: "Pawn_black")
-     black_pawn.update_all(user_id: 1)
-     rook = game.pieces.find_by(name: "Rook_white")
-     rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
-     expect(black_king.find_threat).to eq rook
    end
  end
 
@@ -112,7 +97,6 @@ RSpec.describe King, type: :model do
      black_pawn.update_all(user_id: 1)
      rook = game.pieces.find_by(name: "Rook_white")
      rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
-     expect(black_king.find_threat).to eq rook
      expect(black_king.check_mate?(black_king, rook)).to eq false
    end
 
@@ -128,7 +112,6 @@ RSpec.describe King, type: :model do
      rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
      black_knight = game.pieces.find_by(name:"Knight_black")
      black_knight.update_attributes(x_coord:2, y_coord:5, user_id: 1)
-     expect(black_king.find_threat).to eq rook
      expect(black_king.check_mate?(black_king, rook)).to eq false
    end
 
@@ -146,7 +129,6 @@ RSpec.describe King, type: :model do
      black_piece2 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 3, game_id: game.id, white:false)
      black_piece3 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 4, game_id: game.id, white:false)
      black_piece4 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 5, game_id: game.id, white:false)
-     expect(black_king.find_threat).to eq rook
      expect(black_king.check_mate?(black_king, rook)).to eq true
    end
  end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -1,45 +1,154 @@
 require 'rails_helper'
 
 RSpec.describe King, type: :model do
-  
+
   describe "#valid move?" do
    it "should return true to move one square forward" do
     game = Game.create
     king = FactoryGirl.create :king, x_coord: 5, y_coord: 5, game_id: game.id
    expect(king.valid_move?(6, 5)).to eq(true)
-   end 
+   end
 
    it "should return true to move one square backward" do
     game = Game.create
     king = FactoryGirl.create :king, x_coord: 5, y_coord: 5, game_id: game.id
    expect(king.valid_move?(4, 5)).to eq(true)
-   end 
+   end
 
    it "should return true to move one square up" do
     game = Game.create
     king = FactoryGirl.create :king, x_coord: 5, y_coord: 5, game_id: game.id
    expect(king.valid_move?(5, 4)).to eq(true)
-   end 
+   end
 
    it "should return true to move one square down" do
     game = Game.create
     king = FactoryGirl.create :king, x_coord: 5, y_coord: 5, game_id: game.id
    expect(king.valid_move?(5, 6)).to eq(true)
-   end 
+   end
 
    it "should return true to move one square diagonally" do
     game = Game.create
     king = FactoryGirl.create :king, x_coord: 5, y_coord: 5, game_id: game.id
    expect(king.valid_move?(6, 6)).to eq(true)
-   end 
+   end
 
    it "should return false to move two squares forward" do
     game = Game.create
     king = FactoryGirl.create :king, x_coord: 5, y_coord: 5, game_id: game.id
    expect(king.valid_move?(7, 5)).to eq(false)
-   end 
+   end
 
  end
+ describe "#check?" do
+   it "should return true for pawn to put king in check" do
+     user = FactoryGirl.create :user
+     game = Game.create turn_user_id: user.id
+     king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
+     pawn = FactoryGirl.create :pawn, x_coord: 2, y_coord: 4, game_id: game.id, user_id: user.id
+     expect(king.check?).to eq(true)
+    end
 
+   it "should return false to put king in check" do
+     user = FactoryGirl.create :user
+     game = Game.create turn_user_id: user.id
+     king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
+     rook = FactoryGirl.create :rook, x_coord: 7, y_coord: 4, game_id: game.id, user_id: user.id
+     expect(king.check?).to eq(false)
+    end
+
+    it "should return true for rook to put king in check" do
+     user = FactoryGirl.create :user
+     game = Game.create turn_user_id: user.id
+     king = FactoryGirl.create :king, x_coord: 3, y_coord: 3, game_id: game.id
+     rook = FactoryGirl.create :rook, x_coord: 3, y_coord: 7, game_id: game.id, user_id: user.id
+     expect(king.check?).to eq(true)
+    end
+ end
+
+ describe "#find_threat_and_determine_checkmate" do
+   it "should return true if checkmate is true" do
+     game = Game.create turn_user_id: 1
+     black_king = game.pieces.find_by(name:"King_black")
+     black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 1)
+     white_pawn = game.pieces.where(name: "Pawn_white")
+     white_pawn.delete_all
+     black_pawn = game.pieces.where(name: "Pawn_black")
+     black_pawn.update_all(user_id: 1)
+     rook = game.pieces.find_by(name: "Rook_white")
+     rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
+     black_piece1 = FactoryGirl.create(:pawn,user_id: 1,x_coord:1, y_coord: 3, game_id: game.id, white:false)
+     black_piece2 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 3, game_id: game.id, white:false)
+     black_piece3 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 4, game_id: game.id, white:false)
+     black_piece4 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 5, game_id: game.id, white:false)
+     expect(black_king.find_threat).to eq rook
+     expect(black_king.find_threat_and_determine_checkmate(black_king)).to eq true
+   end
+ end
+
+ describe "#find_threat" do
+   it "should return the piece that is checking the king" do
+     game = Game.create turn_user_id: 1
+     black_king = game.pieces.find_by(name:"King_black")
+     black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 1)
+     white_pawn = game.pieces.where(name: "Pawn_white")
+     white_pawn.delete_all
+     black_pawn = game.pieces.where(name: "Pawn_black")
+     black_pawn.update_all(user_id: 1)
+     rook = game.pieces.find_by(name: "Rook_white")
+     rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
+     expect(black_king.find_threat).to eq rook
+   end
+ end
+
+ describe "#check_mate?" do
+   it "should return false if the king has valid_moves left" do
+     game = Game.create turn_user_id: 1
+     black_king = game.pieces.find_by(name:"King_black")
+     black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 1)
+     white_pawn = game.pieces.where(name: "Pawn_white")
+     white_pawn.delete_all
+     black_pawn = game.pieces.where(name: "Pawn_black")
+     black_pawn.update_all(user_id: 1)
+     rook = game.pieces.find_by(name: "Rook_white")
+     rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
+     expect(black_king.find_threat).to eq rook
+     expect(black_king.check_mate?(black_king, rook)).to eq false
+   end
+
+   it "should return false if any other piece(knight example) can help block king" do
+     game = Game.create turn_user_id: 1
+     black_king = game.pieces.find_by(name:"King_black")
+     black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 1)
+     white_pawn = game.pieces.where(name: "Pawn_white")
+     white_pawn.delete_all
+     black_pawn = game.pieces.where(name: "Pawn_black")
+     black_pawn.update_all(user_id: 1)
+     rook = game.pieces.find_by(name: "Rook_white")
+     rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
+     black_knight = game.pieces.find_by(name:"Knight_black")
+     black_knight.update_attributes(x_coord:2, y_coord:5, user_id: 1)
+     expect(black_king.find_threat).to eq rook
+     expect(black_king.check_mate?(black_king, rook)).to eq false
+   end
+
+   it "should return true if the king has no valid moves, no piece can help block and king cannot capture threat" do
+     game = Game.create turn_user_id: 1
+     black_king = game.pieces.find_by(name:"King_black")
+     black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 1)
+     white_pawn = game.pieces.where(name: "Pawn_white")
+     white_pawn.delete_all
+     black_pawn = game.pieces.where(name: "Pawn_black")
+     black_pawn.update_all(user_id: 1)
+     rook = game.pieces.find_by(name: "Rook_white")
+     rook.update_attributes(x_coord:1, y_coord: 8, user_id: 2)
+     black_piece1 = FactoryGirl.create(:pawn,user_id: 1,x_coord:1, y_coord: 3, game_id: game.id, white:false)
+     black_piece2 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 3, game_id: game.id, white:false)
+     black_piece3 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 4, game_id: game.id, white:false)
+     black_piece4 = FactoryGirl.create(:pawn,user_id: 1,x_coord:2, y_coord: 5, game_id: game.id, white:false)
+     expect(black_king.find_threat).to eq rook
+     expect(black_king.check_mate?(black_king, rook)).to eq true
+   end
+ end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ require 'rspec/rails'
 #end
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
-#ActiveRecord::Migration.maintain_test_schema!
+ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
Hi All!

There are several portions to review:

1. Check logic (king.rb) -> code from feat_check_logic branch and modified slightly here
2. Check if the player is putting their own king into check (piece_controller) --> code from feat_check_logic branch -> moved to private and include in 'verify_valid_move' that is executed in before_action
3. Check mate logic (king.rb) ->  Grouped in 'find_threat_and_determine_checkmate'
    - Find the piece that is putting king in check
    - See if the king can move into a different position, if the king can capture the threat, or if another piece can help block the king from being captured.
4. If the player's king is currently in check, moves are restricted to getting the king out of check (piece_controller)-> 'player_moves_own_king_to_check_or_keeps_king_in_check?' method
    - Also added a column called king_check in pieces model in order to flag if the king is in check (indicated by 1's and 0's)
    - **will need to rake db:migrate
5. If the player put the opponent king in check, and the king cannot get out of check, the game is over (piece_controller #update)
6. Modified king#valid_move logic to restrict moves to one square in all directions

Let me know if you think it should be set up another way in order to expand on all those special features/moves (i.e. stalemate)! Refactoring is also welcome!