### PR TITLE
Bug checkmate opposition logic

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -15,18 +15,21 @@ class PiecesController < ApplicationController
     king_opp = @game.pieces.where(:type =>"King").where.not(:user_id => @game.turn_user_id)[0]
     game_end = false
     if king_opp.check?(king_opp.x_coord, king_opp.y_coord).present?
-      render json: {status: "continue", code: 100, message: "You are in check"}
       if king_opp.find_threat_and_determine_checkmate
         king_opp.update_winner
-        render json: {}, status: 401
         game_end = true
       else
+        flash[:notice] = "#{king_opp.name} is in check!" #need to refresh to see
         king_opp.update_attributes(king_check: 1)
       end
     end
     if game_end == false
       switch_turns
       render json: {}, status: 200
+    else
+      render json: {}, status: 201
+      #somehow will need the code below to pass so we can have a message. Right now below is failing tests and saying the http code is 200 :(
+      #render json: {status: "Not modified (standing in for success)", code: 304, message: "Game over!"}
     end
   end
 

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -43,7 +43,7 @@ class PiecesController < ApplicationController
   end
 
   def verify_valid_move
-    return if @piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) &&
+    return if @piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i, piece_params[:id].to_i,piece_params[:white]== "1") &&
     (@piece.is_obstructed(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == false) &&
     (@piece.contains_own_piece?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == false) &&
     (king_not_moved_to_check_or_king_not_kept_in_check? == true)
@@ -62,7 +62,7 @@ class PiecesController < ApplicationController
   end
 
   def piece_params
-    params.require(:piece).permit(:x_coord, :y_coord)
+    params.require(:piece).permit(:x_coord, :y_coord, :white, :id)
   end
 
   def is_captured
@@ -78,7 +78,7 @@ class PiecesController < ApplicationController
     #this function restricts any other random move if king is in check.
     king = @game.pieces.where(:type =>"King").where(:user_id => @game.turn_user_id)[0]
     if @piece.type == "King"
-      if @piece.check?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i).blank?
+      if @piece.check?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i,piece_params[:id].to_i,piece_params[:white]== "1").blank?
         king.update_attributes(king_check: 0)
         return true
       else
@@ -86,7 +86,7 @@ class PiecesController < ApplicationController
       end
     elsif @piece.type != "King" && king.king_check == 1
       if ([[piece_params[:x_coord].to_i, piece_params[:y_coord].to_i]] & king.check?(king.x_coord, king.y_coord).build_obstruction_array(king.x_coord, king.y_coord)).count == 1 ||
-        (@piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == true &&
+        (@piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i,piece_params[:id].to_i,piece_params[:white]== "1") == true &&
         king.check?(king.x_coord, king.y_coord).x_coord == piece_params[:x_coord].to_i &&
         king.check?(king.x_coord, king.y_coord).y_coord == piece_params[:y_coord].to_i)
         king.update_attributes(king_check: 0)

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -26,6 +26,7 @@ class PiecesController < ApplicationController
       switch_turns
       render json: {}, status: 200
     end
+  end
 
   private
 
@@ -43,7 +44,7 @@ class PiecesController < ApplicationController
   end
 
   def verify_valid_move
-    return if @piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i, piece_params[:id].to_i,piece_params[:white]== "1") &&
+    return if @piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i, @piece.id, @piece.white == true) &&
     (@piece.is_obstructed(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == false) &&
     (@piece.contains_own_piece?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i) == false) &&
     (king_not_moved_to_check_or_king_not_kept_in_check? == true)
@@ -78,7 +79,7 @@ class PiecesController < ApplicationController
     #this function restricts any other random move if king is in check.
     king = @game.pieces.where(:type =>"King").where(:user_id => @game.turn_user_id)[0]
     if @piece.type == "King"
-      if @piece.check?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i,piece_params[:id].to_i,piece_params[:white]== "1").blank?
+      if @piece.check?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i, @piece.id, @piece.white == true).blank?
         king.update_attributes(king_check: 0)
         return true
       else
@@ -86,7 +87,7 @@ class PiecesController < ApplicationController
       end
     elsif @piece.type != "King" && king.king_check == 1
       if ([[piece_params[:x_coord].to_i, piece_params[:y_coord].to_i]] & king.check?(king.x_coord, king.y_coord).build_obstruction_array(king.x_coord, king.y_coord)).count == 1 ||
-        (@piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i,piece_params[:id].to_i,piece_params[:white]== "1") == true &&
+        (@piece.valid_move?(piece_params[:x_coord].to_i, piece_params[:y_coord].to_i, @piece.id, @piece.white == true) == true &&
         king.check?(king.x_coord, king.y_coord).x_coord == piece_params[:x_coord].to_i &&
         king.check?(king.x_coord, king.y_coord).y_coord == piece_params[:y_coord].to_i)
         king.update_attributes(king_check: 0)

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,6 +1,6 @@
 class Bishop < Piece
 
-  def valid_move?(new_x_coord, new_y_coord)
+  def valid_move?(new_x_coord, new_y_coord, id = nil, color = nil)
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
 

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,6 +1,6 @@
 class King < Piece
 
-  def valid_move?(new_x_coord, new_y_coord)
+  def valid_move?(new_x_coord, new_y_coord, id = nil, color = nil)
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
 
@@ -9,10 +9,10 @@ class King < Piece
     (y_distance == 1 && y_distance == x_distance)
   end
 
-  def check?(x_coord, y_coord)
+  def check?(x_coord, y_coord, id = nil, color = nil)
     game.pieces.each do | f |
       if f.user_id != self.user_id && f.x_coord != nil
-        if f.valid_move?(x_coord, y_coord) == true && f.is_obstructed(x_coord, y_coord) == false
+        if f.valid_move?(x_coord, y_coord, id = nil, color = nil) == true && f.is_obstructed(x_coord, y_coord) == false
           return f
           break
         end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -12,7 +12,7 @@ class King < Piece
   def check?(x_coord, y_coord, id = nil, color = nil)
     game.pieces.each do | f |
       if f.user_id != self.user_id && f.x_coord != nil
-        if f.valid_move?(x_coord, y_coord, id = nil, color = nil) == true && f.is_obstructed(x_coord, y_coord) == false
+        if f.valid_move?(x_coord, y_coord, id, color) == true && f.is_obstructed(x_coord, y_coord) == false
           return f
           break
         end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -50,7 +50,7 @@ class King < Piece
     possible_coords = []
     (1..8).each do |num1|
       (1..8).each do |num2|
-        if valid_move?(num1,num2) == true && contains_own_piece?(num1,num2) == false
+        if valid_move?(num1,num2) == true && contains_own_piece?(num1,num2) == false && check?(num1, num2).blank?
           possible_coords << [num1, num2]
         end
       end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,9 +1,9 @@
 class Knight < Piece
 
-  def valid_move?(new_x_coord, new_y_coord)
+  def valid_move?(new_x_coord, new_y_coord, id = nil, color = nil)
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
-    
-    (x_distance == 1 && y_distance == 2) || (x_distance == 2 && y_distance == 1) 
+
+    (x_distance == 1 && y_distance == 2) || (x_distance == 2 && y_distance == 1)
   end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -6,17 +6,17 @@ class Pawn < Piece
 # ----- lines 9-12 Diagonal capture -----
 # ----- lines 13-20 Vertical opening and subsequent moves valid only if there is no opposition piece/no piece at destination coordinate-------
 # ----- Same color piece at destination coordinate is checked in the verify_valid_move in the piece controller -----
-    if (x_distance == y_distance) && !white? && opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
+    if (x_distance == y_distance) && !white? && opposition_piece?(new_x_coord, new_y_coord, id, color)
         new_y_coord == y_coord + 1
-    elsif (x_distance == y_distance) && white? && opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
+    elsif (x_distance == y_distance) && white? && opposition_piece?(new_x_coord, new_y_coord, id, color)
         new_y_coord == y_coord - 1
-    elsif y_coord == 2 && black? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
+    elsif y_coord == 2 && black? && !opposition_piece?(new_x_coord, new_y_coord,  id, color)
           x_distance == 0 && (new_y_coord == 3 || new_y_coord == 4)
-    elsif y_coord == 7 && white? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
+    elsif y_coord == 7 && white? && !opposition_piece?(new_x_coord, new_y_coord,  id, color)
         x_distance == 0 && (new_y_coord == 6 || new_y_coord == 5)
-    elsif !white? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
+    elsif !white? && !opposition_piece?(new_x_coord, new_y_coord,  id, color)
         (x_distance == 0) && (new_y_coord == (y_coord + 1))
-    elsif white? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
+    elsif white? && !opposition_piece?(new_x_coord, new_y_coord,  id, color)
         (x_distance == 0) && (new_y_coord == (y_coord - 1))
     else
       false

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,22 +1,22 @@
 class Pawn < Piece
 
-  def valid_move?(new_x_coord, new_y_coord)
+  def valid_move?(new_x_coord, new_y_coord, id = nil, color = nil)
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
 # ----- lines 9-12 Diagonal capture -----
 # ----- lines 13-20 Vertical opening and subsequent moves valid only if there is no opposition piece/no piece at destination coordinate-------
 # ----- Same color piece at destination coordinate is checked in the verify_valid_move in the piece controller -----
-    if (x_distance == y_distance) && !white? && opposition_piece?(new_x_coord, new_y_coord)
+    if (x_distance == y_distance) && !white? && opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
         new_y_coord == y_coord + 1
-    elsif (x_distance == y_distance) && white? && opposition_piece?(new_x_coord, new_y_coord)
+    elsif (x_distance == y_distance) && white? && opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
         new_y_coord == y_coord - 1
-    elsif y_coord == 2 && black? && !opposition_piece?(new_x_coord, new_y_coord)
+    elsif y_coord == 2 && black? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
           x_distance == 0 && (new_y_coord == 3 || new_y_coord == 4)
-    elsif y_coord == 7 && white? && !opposition_piece?(new_x_coord, new_y_coord)
+    elsif y_coord == 7 && white? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
         x_distance == 0 && (new_y_coord == 6 || new_y_coord == 5)
-    elsif !white? && !opposition_piece?(new_x_coord, new_y_coord)
+    elsif !white? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
         (x_distance == 0) && (new_y_coord == (y_coord + 1))
-    elsif white? && !opposition_piece?(new_x_coord, new_y_coord)
+    elsif white? && !opposition_piece?(new_x_coord, new_y_coord, id = nil, color = nil)
         (x_distance == 0) && (new_y_coord == (y_coord - 1))
     else
       false
@@ -26,9 +26,7 @@ class Pawn < Piece
   def en_passant?(new_x_coord, new_y_coord)
     return false unless ((new_y_coord == y_coord + 1 && !white?) || (new_y_coord == y_coord - 1 && white?)) && ((new_x_coord == x_coord + 1) || (new_x_coord == x_coord - 1)) && ((new_y_coord == 3 && white?) || (new_y_coord == 6 && !white?))
     other_piece = game.pieces.where(y_coord: y_coord, x_coord: new_x_coord, type: "Pawn").first
-    return false if other_piece.nil? || other_piece.move_number != 1 
+    return false if other_piece.nil? || other_piece.move_number != 1
     return true
    end
 end
-
-

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -14,9 +14,25 @@ class Piece < ApplicationRecord
     piece.present? && piece.white == white
   end
 
-  def opposition_piece?(x_end, y_end)
+  def opposition_piece?(x_end, y_end, id = nil, color = nil)
     piece = game.pieces.where("x_coord = ? AND y_coord = ?", x_end, y_end).first
-    piece.present? && piece.white != white
+    if id == nil
+      if piece.blank?
+        return false
+      elsif piece.white != white
+        return true
+      elsif piece.white == white
+        return false
+      end
+    elsif self.id == id && piece.blank? #empty square
+      return false
+    elsif self.id == id && piece.white != white
+      return true
+    elsif self.id != id && self.white != color #
+      return true
+    else
+      return false
+    end
   end
 
   #build_obstruction_array is identical to is_obstruct, except that we want the array, and not the boolean

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -26,9 +26,9 @@ class Piece < ApplicationRecord
       end
     elsif self.id == id && piece.blank? #empty square
       return false
-    elsif self.id == id && piece.white != white
+    elsif self.id == id && piece.white != white #the piece is moving into square that has a opposite piece
       return true
-    elsif self.id != id && self.white != color #
+    elsif self.id != id && self.white != color # ex: King moving to square above pawn, and when performing king.check?, pawn will recognize there is an opposition piece, making the vertical move false
       return true
     else
       return false

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,6 +1,6 @@
 class Queen < Piece
 
-  def valid_move?(new_x_coord, new_y_coord)
+  def valid_move?(new_x_coord, new_y_coord, id = nil, color = nil)
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
 

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,6 +1,6 @@
 class Rook < Piece
 
-  def valid_move?(new_x_coord, new_y_coord)
+  def valid_move?(new_x_coord, new_y_coord, id = nil, color = nil)
     x_distance = x_distance(new_x_coord)
     y_distance = y_distance(new_y_coord)
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,5 +1,7 @@
 <script>
     $( function() {
+
+
       //Ultimately, we'll have to assign droppable square based on piece rules and position of other pieces
       $("td").addClass("droppable-square");
       $( ".selectable-piece" ).draggable({
@@ -32,7 +34,9 @@
             data: {
               piece: {
                 x_coord: $(this).data("x-coord"),
-                y_coord: $(this).data("y-coord")
+                y_coord: $(this).data("y-coord"),
+                id: ui.draggable.attr("id"),
+                white: ui.draggable.data("white")
               },
             },
             error:  function(){
@@ -46,8 +50,6 @@
 
     });
 </script>
-
-
 
 <div class="background">
   <div class="row">

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -35,8 +35,6 @@
               piece: {
                 x_coord: $(this).data("x-coord"),
                 y_coord: $(this).data("y-coord"),
-                id: ui.draggable.attr("id"),
-                white: ui.draggable.data("white")
               },
             },
             error:  function(){

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,8 +20,6 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  #username: postgres
-  #password: password
   username: postgres
   password: password
   host: localhost

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,8 +22,8 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   #username: postgres
   #password: password
-  username: postgres
-  password: password
+  username: monicasira
+  password:
   host: localhost
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,8 +20,10 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: postgres
-  password: password
+  #username: postgres
+  #password: password
+  username: monicasira
+  password:
   host: localhost
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,8 +22,8 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   #username: postgres
   #password: password
-  username: monicasira
-  password:
+  username: postgres
+  password: password
   host: localhost
 
 development:

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -118,47 +118,48 @@ RSpec.describe PiecesController, type: :controller do
       post :update, params: {id:pawn.id, piece:{x_coord: 1, y_coord:6}}
       expect(response).to have_http_status(422)
     end
-  it "should return status 401 if opponent king is in check and cannot move out of check" do
-    current_user = FactoryGirl.create(:user, id: 1)
-    sign_in current_user
-    game = Game.create turn_user_id: 1, white_player_user_id: 1, black_player_user_id: 2
-    black_king = game.pieces.find_by(name:"King_black")
-    black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 2)
-    white_pawn = game.pieces.where(name: "Pawn_white")
-    white_pawn.delete_all
-    black_pawn = game.pieces.where(name: "Pawn_black")
-    black_pawn.update_all(user_id: 2)
-    rook = game.pieces.find_by(name: "Rook_white")
-    rook.update_attributes(user_id: 1, x_coord:1, y_coord:8)
-    black_piece1 = FactoryGirl.create(:pawn,user_id: 2,x_coord:1, y_coord: 3, game_id: game.id, white:false)
-    black_piece2 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 3, game_id: game.id, white:false)
-    black_piece3 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 4, game_id: game.id, white:false)
-    black_piece4 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 5, game_id: game.id, white:false)
-    post :update, params: {id: rook.id, piece: {x_coord:1, y_coord:7 }}
-    expect(response).to have_http_status(401)
-  end
 
-  it "should return status 401 if opponent king is in check and cannot move out of check" do
-    current_user = FactoryGirl.create(:user, id: 1)
-    sign_in current_user
-    game = Game.create turn_user_id: 1, white_player_user_id: 1, black_player_user_id: 2
-    black_king = game.pieces.find_by(name:"King_black")
-    black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 2)
-    white_pawn = game.pieces.where(name: "Pawn_white")
-    white_pawn.delete_all
-    black_pawn = game.pieces.where(name: "Pawn_black")
-    black_pawn.update_all(user_id: 2)
-    rook = game.pieces.find_by(name: "Rook_white")
-    rook.update_attributes(user_id: 1, x_coord:1, y_coord:8)
-    black_piece1 = FactoryGirl.create(:pawn,user_id: 2,x_coord:1, y_coord: 3, game_id: game.id, white:false)
-    black_piece2 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 3, game_id: game.id, white:false)
-    black_piece3 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 4, game_id: game.id, white:false)
-    post :update, params: {id: rook.id, piece: {x_coord:1, y_coord:7 }}
-    black_king.reload
-    expect(black_king.king_check).to eq 1
-    expect(response).to have_http_status(200)
+    it "should return status 201 if opponent king is in check and cannot move out of check" do
+      current_user = FactoryGirl.create(:user, id: 1)
+      sign_in current_user
+      game = Game.create turn_user_id: 1, white_player_user_id: 1, black_player_user_id: 2
+      black_king = game.pieces.find_by(name:"King_black")
+      black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 2)
+      white_pawn = game.pieces.where(name: "Pawn_white")
+      white_pawn.delete_all
+      black_pawn = game.pieces.where(name: "Pawn_black")
+      black_pawn.update_all(user_id: 2)
+      rook = game.pieces.find_by(name: "Rook_white")
+      rook.update_attributes(user_id: 1, x_coord:1, y_coord:8)
+      black_piece1 = FactoryGirl.create(:pawn,user_id: 2,x_coord:1, y_coord: 3, game_id: game.id, white:false)
+      black_piece2 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 3, game_id: game.id, white:false)
+      black_piece3 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 4, game_id: game.id, white:false)
+      black_piece4 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 5, game_id: game.id, white:false)
+      post :update, params: {id: rook.id, piece: {x_coord:1, y_coord:7 }}
+      expect(response).to have_http_status(201)
+    end
+
+    it "should return status 200 if opponent king is in check and can move out of check" do
+      current_user = FactoryGirl.create(:user, id: 1)
+      sign_in current_user
+      game = Game.create turn_user_id: 1, white_player_user_id: 1, black_player_user_id: 2
+      black_king = game.pieces.find_by(name:"King_black")
+      black_king.update_attributes(x_coord:1, y_coord: 4, user_id: 2)
+      white_pawn = game.pieces.where(name: "Pawn_white")
+      white_pawn.delete_all
+      black_pawn = game.pieces.where(name: "Pawn_black")
+      black_pawn.update_all(user_id: 2)
+      rook = game.pieces.find_by(name: "Rook_white")
+      rook.update_attributes(user_id: 1, x_coord:1, y_coord:8)
+      black_piece1 = FactoryGirl.create(:pawn,user_id: 2,x_coord:1, y_coord: 3, game_id: game.id, white:false)
+      black_piece2 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 3, game_id: game.id, white:false)
+      black_piece3 = FactoryGirl.create(:pawn,user_id: 2,x_coord:2, y_coord: 4, game_id: game.id, white:false)
+      post :update, params: {id: rook.id, piece: {x_coord:1, y_coord:7 }}
+      black_king.reload
+      expect(black_king.king_check).to eq 1
+      expect(response).to have_http_status(200)
+    end
   end
-end
 
 
 end


### PR DESCRIPTION
Hi All,

This branch 
- Fixes move logic to allow for King.check? to recognize pawn vertical movement as non-threats.
- Allows checkmate move to be made successfully
- Updates "you are in check alert" to be a flash alert since controller tends to throw an error with more than one render.

Will still need incorporate en_passant and a proper game_end message.