### PR TITLE
fixed styling issues with chat feature

### DIFF
--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -27,7 +27,8 @@
 }
 
 .chatbox {
-  height: 325px;
+  height: flex;
+  padding-bottom: 20px;
 }
 
 .column {

--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -62,6 +62,14 @@
   text-shadow: rgba(0, 0, 0, 0.10) 1px 1px;
 }
 
+.btn-chat {
+  color: white;
+  background-color: #000000;
+  border-color: gray;
+  border-radius: 3px;
+  text-shadow: rgba(0, 0, 0, 0.10) 1px 1px;
+}
+
 .btn-newgame {
   color: white;
   background-color: #000000;
@@ -86,7 +94,7 @@
   box-shadow: 0px 1px 3px #2a2a2a;
 }
 
-.btn-black:hover, .btn-warning:hover {
+.btn-black:hover, .btn-chat:hover, .btn-warning:hover {
   background-color: #595959;
   color: white;
   border-color: white;
@@ -273,4 +281,5 @@ ul {
   margin-top: 5px;
   margin-bottom: 5px;
   padding: 5px 5px;
+  width: 300px; 
 }

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -2,8 +2,20 @@
   <div class="row">
     <div class="column">
       <div class="booyah-box chatbox">
-        <p> Possible chat box goes here </p>
+        <% @messages.each do |message| %>
+          <div class = "message-box">
+            <!-- NOTE: For now, I've left out the user email, as I can't think how to get this from Firebase. Would have to store everything on firebase -->
+            <!-- <p class = "text-muted"><%= message.user.email %></p> -->
+            <p><%= message.body %></p>
+          </div>
+        <% end %>
+
+        <%= simple_form_for @message, url: game_messages_path(@game) do |f| %>
+          <%= f.input :body, class: "enter-message-box", prompt: "Enter your message" %>
+          <div class="chatbutton"> <%= f.submit "Send", class: "float-right btn-sm btn-chat submit-message", remote: true %> </div>
+        <% end %>
       </div>
+      
       <div class="booyah-box move-history">
         <p> Possible list of last X moves </p>
       </div>
@@ -47,22 +59,6 @@
           <% end %>
         </div>
       </div>
-
-      <div class = "all-messages">
-        <% @messages.each do |message| %>
-          <div class = "message-box">
-            <!-- NOTE: For now, I've left out the user email, as I can't think how to get this from Firebase. Would have to store everything on firebase -->
-            <!-- <p class = "text-muted"><%= message.user.email %></p> -->
-            <p><%= message.body %></p>
-          </div>
-
-        <% end %>
-      </div>
-
-      <%= simple_form_for @message, url: game_messages_path(@game) do |f| %>
-        <%= f.input :body, class: "enter-message-box", prompt: "Enter your message" %>
-        <%= f.submit "Send", class: "btn btn-primary submit-message", remote: true %>
-      <% end %>
 
       <% if @game.users.count > 1 %>
         <%= simple_form_for @game, url: forfeit_game_path(@game) do |f| %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,9 +44,9 @@ ActiveRecord::Schema.define(version: 20171121234856) do
     t.integer "y_coord"
     t.integer "game_id"
     t.integer "user_id"
+    t.integer "move_number", default: 0
     t.string "type"
     t.boolean "captured", default: false, null: false
-    t.integer "move_number", default: 0
     t.integer "king_check", default: 0
   end
 


### PR DESCRIPTION
I put the chat feature in the box we'd designed for it and improved some of the styling.  Still need to get rid of "Body" text once I figure out how to access the code.

Excellent job on the chat stuff, but unless there's a way to have old messages scroll off the top, we have a problem with it forcing down the bottom of the page.  If we have more than a few messages  it breaks the page layout (plus to keep chatting you'd have to scroll down away from the board.)  I wonder if we should do it as a pop up instead?  
