### PR TITLE
Bug Heroku chat and font path

### DIFF
--- a/app/assets/stylesheets/font.scss
+++ b/app/assets/stylesheets/font.scss
@@ -6,7 +6,7 @@
  * Fully installable fonts can be purchased at http://www.fontspring.com
  *
  * The fonts included in this stylesheet are subject to the End User License you purchased
- * from Fontspring. The fonts are protected under domestic and international trademark and 
+ * from Fontspring. The fonts are protected under domestic and international trademark and
  * copyright law. You are prohibited from modifying, reverse engineering, duplicating, or
  * distributing this font software.
  *
@@ -25,10 +25,9 @@
 
 @font-face {
     font-family: 'didonesque-roman';
-    src: url('didonesque-roman-webfont.woff2') format('woff2'),
-         url('didonesque-roman-webfont.woff') format('woff');
+    src: font-url('didonesque-roman-webfont.woff2') format('woff2'),
+         font-url('didonesque-roman-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
 }
-

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -115,7 +115,6 @@
 <script src="https://www.gstatic.com/firebasejs/4.6.2/firebase.js"></script>
 <script>
   var lastMessagePageShown = <%= @messages.last.to_json.html_safe %>;
-  console.log(lastMessagePageShown);
   // Initialize Firebase
   var config = {
     apiKey: "AIzaSyDUMKEQ7hnoKOhw4JzjKNylY2akSXyGsA4",
@@ -129,17 +128,20 @@
   firebase.initializeApp(config);
 
   // Get a reference to the database service
+
   var database = firebase.database();
-  var messageRef = database.ref('games/' + <%= @game.id %> + '/message');
-  messageRef.on('value', function(snapshot) {
-    var values = snapshot.val();
-    var ids = Object.keys(values);
-    var lastId = ids[ids.length - 1];
-    var lastMessage = values[lastId];
-    if(lastMessagePageShown.id < lastMessage.id) {
-      $('.all-messages').append("<div class = 'message-box'><p>" + lastMessage.body +"</p></div>")
-    }
-  });
+  if (lastMessagePageShown !== null){
+    var messageRef = database.ref('games/' + <%= @game.id %> + '/message');
+    messageRef.on('value', function(snapshot) {
+      var values = snapshot.val();
+      var ids = Object.keys(values);
+      var lastId = ids[ids.length - 1];
+      var lastMessage = values[lastId];
+      if(lastMessagePageShown.id < lastMessage.id) {
+        $('.all-messages').append("<div class = 'message-box'><p>" + lastMessage.body +"</p></div>")
+      }
+    });
+  };
 
   var moveRef = database.ref('games/' + <%= @game.id %> + '/pieces');
   moveRef.on('value', function(snapshot) {

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,8 +20,10 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: postgres
-  password: password
+  #username: postgres
+  #password: password
+  username: monicasira
+  password:
   host: localhost
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,10 +20,8 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  #username: postgres
-  #password: password
-  username: monicasira
-  password:
+  username: postgres
+  password: password
   host: localhost
 
 development:

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,9 +7,9 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
-
+Rails.application.config.assets.paths << Rails.root.join("app", "assets", "fonts")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w( test_board.js )
+Rails.application.config.assets.precompile += %w( test_board.js '.woff2' '.woff')


### PR DESCRIPTION
Hi All,

As discussed earlier, Heroku is not completely execute the update method(piece_controller) after the first piece is moved. 
In an attempt to fix that, we are trying to get rid of the the following errors:
1. Chat messages -> server tries to find messages, although we didn't write any, and returns errors like 'null object'. Therefore, I put an if statement to tell it to run methods on the messages if there are any.
2. Font path error -> Server tries to find fonts using the wrong path like localhost/asset/font/font_name. Therefore, tweaked it according to Stackoverflow post about paths.

Hopefully these two changes will allow Heroku to work! If not, then more debugging!