### PR TITLE
hide api key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,5 @@ end
 gem 'jquery-ui-rails'
 
 gem 'firebase'
+
+gem "figaro"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
     ffi (1.9.18)
+    figaro (1.1.1)
+      thor (~> 0.14)
     firebase (0.2.6)
       httpclient
       json
@@ -244,6 +246,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   factory_girl_rails (~> 4.0)
+  figaro
   firebase
   font-awesome-rails
   jbuilder (~> 2.5)
@@ -267,4 +270,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.0

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -156,7 +156,7 @@
   var lastMessagePageShown = <%= @messages.last.to_json.html_safe %>;
   // Initialize Firebase
   var config = {
-    apiKey: "AIzaSyDUMKEQ7hnoKOhw4JzjKNylY2akSXyGsA4",
+    apiKey: ENV['API_KEY'],
     authDomain: "chess-space.firebaseapp.com",
     databaseURL: "https://chess-space.firebaseio.com",
     projectId: "chess-space",


### PR DESCRIPTION
Using the figaro gem, this hides our API key. It should still work for heroku since it was set previously.