### PR TITLE
Updated Move History to show on page

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -34,6 +34,7 @@ class PiecesController < ApplicationController
       game_end = true
     end
     if game_end == false && !(@piece.type == "Pawn" && @piece.pawn_promotion?)
+      update_moves
       switch_turns
       render json: {}, status: 200
     else
@@ -127,5 +128,9 @@ class PiecesController < ApplicationController
     else
       return true
     end
+  end
+
+  def update_moves
+    Move.create(piece_user_id: @piece.user_id, piece_type: @piece.type, x_coord: @piece.x_coord, y_coord: @piece.y_coord, game_id:@game.id)
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,7 +3,7 @@ class Game < ApplicationRecord
   has_many :users, through: :user_games
   has_many :pieces
   has_many :messages
-  has_many :moves, through: :pieces  
+  has_many :moves 
 
   after_create :lay_out_board!
 
@@ -87,5 +87,7 @@ class Game < ApplicationRecord
   def loser
     User.find_by_id(loser_user_id)
   end
+
+
 
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,17 +1,11 @@
 class Move < ApplicationRecord
-    attr_accessor :black, :white, :location
+  belongs_to :game
 
-    def notation
-     @black = black_player_user_id
-     @white = white_player_user_id
+  def notation (piece_type, x_coord, y_coord)
+    x_mapping = { 1 => "a", 2 => "b", 3 => "c", 4 => "d", 5 => "e", 6 => "f", 7 => "g", 8 => "h" }
+    y_mapping = { 1 => "8", 2 => "7", 3 => "6", 4 => "5", 5 => "4", 6 => "3", 7 => "2", 8 => "1" }
+    piece_mapping = { "King" => "K", "Queen" => "Q", "Bishop" => "B", "Knight" => "N", "Rook" => "R", "Pawn" => " " }
+    return "#{piece_mapping[piece_type]}" + "#{x_mapping[x_coord]}" + "#{y_mapping[y_coord]}"
+  end
 
- 
-     x = { 1 => "a", 2 => "b", 3 => "c", 4 => "d", 5 => "e", 6 => "f", 7 => "g", 8 => "h" }
-     y = { 1 => "8", 2 => "7", 3 => "6", 4 => "5", 5 => "4", 6 => "3", 7 => "2", 8 => "1" }
-     piece = { "King" => "K", "Queen" => "Q", "Bishop" => "B", "Knight" => "N", "Rook" => "R", "Pawn" => " " }
- 
-     @location = "#{piece}" + "#{x}" + "#{y}"
-     @blackmove = location.black
-     @whitemove = location.white
-   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -165,8 +165,4 @@ class Piece < ApplicationRecord
     FIREBASE.push("games/" + self.game.id.to_s + "/pieces/", { id: self.id, x_coord: self.x_coord, y_coord: self.y_coord, game_id: self.game_id, timestamp: Time.now.to_i, '.priority': 1 })
   end
 
-  def update_move
-    #piece.update_attributes(x_coord, x_end, y_coord, y_end) to display in show page
-  end
-
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -17,7 +17,22 @@
       </div>
 
       <div class="booyah-box move-history">
-        <p> <%= "#{@whitemove} / #{@blackmove}" %> </p>
+        <div class="row">
+            <% @game.moves.each_with_index do |move| %>
+              <% if move.present? && move.piece_user_id == @game.white_player_user_id %>
+                <div class="col-4 text-right">
+                  <p> <%= "#{move.notation(move.piece_type, move.x_coord, move.y_coord)}" %> </p>
+                </div>
+              <% else %>
+                <div class="col-4 text-center">
+                  <p>/</p>
+                </div>
+                <div class="col-4 text-left">
+                  <p> <%= "#{move.notation(move.piece_type, move.x_coord, move.y_coord)}" %> </p>
+                </div>
+              <% end %>
+            <% end %>
+        </div>
       </div>
     </div>
 

--- a/db/migrate/20171217193844_add_column_piece_type_to_moves.rb
+++ b/db/migrate/20171217193844_add_column_piece_type_to_moves.rb
@@ -1,0 +1,5 @@
+class AddColumnPieceTypeToMoves < ActiveRecord::Migration[5.1]
+  def change
+    add_column :moves, :piece_type, :string
+  end
+end

--- a/db/migrate/20171217203845_add_column_piece_user_id_to_moves.rb
+++ b/db/migrate/20171217203845_add_column_piece_user_id_to_moves.rb
@@ -1,0 +1,5 @@
+class AddColumnPieceUserIdToMoves < ActiveRecord::Migration[5.1]
+  def change
+    add_column :moves, :piece_user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,8 +84,10 @@ ActiveRecord::Schema.define(version: 20171217203845) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171207052604) do
+ActiveRecord::Schema.define(version: 20171217203845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,8 @@ ActiveRecord::Schema.define(version: 20171207052604) do
     t.integer "piece_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "piece_type"
+    t.integer "piece_user_id"
   end
 
   create_table "pieces", force: :cascade do |t|
@@ -82,10 +84,8 @@ ActiveRecord::Schema.define(version: 20171207052604) do
     t.inet "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -237,5 +237,21 @@ RSpec.describe PiecesController, type: :controller do
       post :update, params: {id: white_queen.id, piece: {x_coord:6, y_coord:2 }}
       expect(response).to have_http_status(201)
     end
+    it "should update the piece move into the moves model" do
+      current_user = FactoryGirl.create(:user, id: 1)
+      current_user2 = FactoryGirl.create(:user, id: 2)
+
+      sign_in current_user
+      sign_in current_user2
+
+      game = Game.create turn_user_id: 2, white_player_user_id: 1, black_player_user_id: 2
+      game.pieces.delete_all
+      black_king = FactoryGirl.create(:king, x_coord:5, y_coord: 1, user_id: 2, game_id: game.id, white: false)
+      white_king = FactoryGirl.create(:king, user_id: 1, x_coord:5, y_coord: 8, game_id: game.id, white:true)
+      black_pawn = FactoryGirl.create(:pawn, x_coord: 4, y_coord: 2, game_id: game.id, white:false, user_id: 2)
+      post :update, params: {id: black_pawn.id, piece: {x_coord:4, y_coord:3 }}
+      expect(game.moves.last.x_coord).to eq 4
+      expect(game.moves.last.piece_type).to eq "Pawn"
+    end
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1,4 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Move, type: :model do
+  describe "#update_piece_move" do
+    it "should update the piece move into the moves model" do
+
+    end
+  end
 end


### PR DESCRIPTION
Hi all,

I made the following changes:
1. Added a method to update the Moves model in the pieces controller (This is similar to the update_move method written earlier.)
2. Added piece_type and user_id to moves model ***Must rake db:migrate.
3. Since all moves are stored in the moves model, i iterated the moves in show.html.erb. I used the notation method(previously written) in moves.rb to display the moves in chess notation.

**Issue 1** The booyah-box keeps expanding as more moves are added to the box. Need help!
**Issue 2** It looks like Firebase is currently not updating both player's page as our API key does not exist, as mentioned in Slack.

@denisekelsey I did not make any changes to css files. If you could double check my changes to ensure none of your changes were affected, that would be great!